### PR TITLE
added Certbot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ACME-DNS-NC
 Simple helper script for various [Let's Encrypt][1] clients.
-Developed for [GetSSL][2] and [ACME.sh][3], tested at Debian and Ubuntu.
+Developed for [GetSSL][2], [ACME.sh][3] and [Certbot][4], tested at Debian and Ubuntu.
 
 ## Initial setup
 Download or clone the archive and extract it to a new folder.
@@ -39,3 +39,4 @@ Important: This project is **not** affiliated with netcup GmbH!
 [1]: https://letsencrypt.org/docs/client-options/
 [2]: https://github.com/srvrco/getssl
 [3]: https://github.com/Neilpang/acme.sh
+[4]: https://github.com/certbot/certbot

--- a/scripts/certbot-nc-auth
+++ b/scripts/certbot-nc-auth
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# --manual-auth-hook
+if [ -n "${CERTBOT_DOMAIN}" ] && [ -n "${CERTBOT_VALIDATION}" ]
+then
+	"$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/acme-dns-nc" --add "${CERTBOT_DOMAIN}" "${CERTBOT_VALIDATION}"
+
+	# netcup updates DNS data every 5 minutes, 1 extra minute safety margin
+	#sleep $(( 6 - $(date "+%_M" -d "-5 minutes") % 5 ))m
+	sleep 10m
+else
+	echo "env variables missing"
+	false
+fi

--- a/scripts/certbot-nc-cleanup
+++ b/scripts/certbot-nc-cleanup
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# --manual-cleanup-hook
+if [ -n "${CERTBOT_DOMAIN}" ] && [ -n "${CERTBOT_VALIDATION}" ]
+then
+	"$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/acme-dns-nc" --del "${CERTBOT_DOMAIN}" "${CERTBOT_VALIDATION}"
+else
+	echo "env variables missing"
+	false
+fi


### PR DESCRIPTION
Hallo, ich habe certbot-Support hinzugefügt. Da Netcup die DNS-Daten nicht sofort aktualisiert und Certbot nicht von sich aus wartet, ist jetzt ein sleep 10m drin. Ich hatte versucht es auf die nächste 5-Minuten-Zeit aufzurunden, das funktionierte leider nicht immer.

Beispielaufruf:

`certbot certonly --manual --preferred-challenges dns --manual-auth-hook /PATH/TO/acme-dns-nc/scripts/certbot-nc-auth --manual-cleanup-hook /PATH/TO/acme-dns-nc/scripts/certbot-nc-cleanup -d 'DOMAIN.de'`